### PR TITLE
Input name modal

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,8 +4,8 @@ import {
   RouterProvider,
 } from "react-router-dom";
 
-import MainPage from "core/main-page";
-import TatetiPage from "core/tateti/page";
+import MainPage from "src/core/main-page";
+import TatetiPage from "src/core/tateti/page";
 
 const router = createBrowserRouter([
   {

--- a/src/core/tateti/modal-input-name/index.ts
+++ b/src/core/tateti/modal-input-name/index.ts
@@ -1,0 +1,34 @@
+import styled from "styled-components";
+import InputNameModal from "./input-name-modal.component";
+
+export default styled(InputNameModal) `
+
+display: flex;
+align-items: center;
+justify-content: center;
+margin: 0px auto;
+width: 400px;
+padding: 3rem;
+border: 1px solid #ccc;
+border-radius: 1em;
+font-size: larger;
+background-color: black;
+color: #ffff;
+  
+ul {
+list-style: none;
+padding: 0;
+margin: 0;
+}
+li + li {
+margin-top: 1em;
+}
+input{
+padding: 2%;
+}
+button {
+font-size: 20px;
+border-radius: 22%;
+padding: 2%;
+} 
+`;

--- a/src/core/tateti/modal-input-name/input-name-modal.component.tsx
+++ b/src/core/tateti/modal-input-name/input-name-modal.component.tsx
@@ -1,0 +1,38 @@
+import { FunctionComponent, useState } from "react"
+import Modal from "src/components/modal"
+
+const InputNameModal: FunctionComponent<Props> = ({open, onSubmit, className})=> {
+    const [player1, setPlayer1] = useState('');
+    const [player2, setPlayer2] = useState('');
+
+    const onSubmitForm = (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+
+        onSubmit(player1, player2);
+    }
+
+    return (
+        <Modal open={open} >
+            <form onSubmit={onSubmitForm} className={className}>
+                <ul>
+                    <li>
+                <label>Enter the player one's name</label>
+                <input placeholder="input name" value={player1} onChange={(e) => setPlayer1(e.target.value)}/>
+                    </li>
+                    <li>
+                <label>Enter the player two's name</label>
+                <input placeholder="input name" value={player2} onChange={(e) => setPlayer2(e.target.value)} />
+                    </li>
+                </ul>
+                <button type="submit" disabled={!player1 || !player2} > Play </button>
+            </form>
+        </Modal>
+    )
+}
+export default InputNameModal;
+
+interface Props {
+    className?: string;
+    open: boolean;
+    onSubmit: (value1: string, value2: string) => void;
+}

--- a/src/core/tateti/page/page.component.tsx
+++ b/src/core/tateti/page/page.component.tsx
@@ -3,13 +3,14 @@ import Board from "../board";
 import AlertWinner from "../alert-winner";
 import TurnName from "../turn-name";
 import { Mark, PlayerByMark } from "../types";
+import InputNameModal from "src/core/tateti/modal-input-name";
 
 const TatetiPage: FunctionComponent<Props> =({className}) => {
     const [winner ,setWinner] = useState<Mark | undefined>(undefined);
     const [currentTurn, setCurrentTurn] = useState<Mark>(Mark.X);
     const [players, setPlayers] = useState<PlayerByMark | undefined>(undefined);
-
-    
+    const [showModal, setShowModal] = useState(false);
+  
     const onMark = ()=> {
         setCurrentTurn(currentTurn === Mark.X ? Mark.O : Mark.X)
     }
@@ -32,10 +33,7 @@ const TatetiPage: FunctionComponent<Props> =({className}) => {
         });
     }
 
-    const initGame = ()=>{
-        const playerOneName = prompt("Enter the player one's name")
-        const playerTwoName = prompt("Enter the player two's name")
-        if (!playerOneName || !playerTwoName) return;
+    const initGame = (playerOneName: string, playerTwoName: string) => {
         setPlayers({
             [Mark.X]: {
                 name: playerOneName,
@@ -48,12 +46,14 @@ const TatetiPage: FunctionComponent<Props> =({className}) => {
                 mark:Mark.O,
             }
         })
+
+        setShowModal(false);
     }
     return (
     <div className={className}>
         <h1 className="title">Tateti</h1>
         {!players &&
-        <button className="buttonPlay" onClick={initGame}>Play</button>
+        <button className="buttonPlay" onClick={() => setShowModal(true)} >Play</button>
         }
         {(!winner && players) &&
         <TurnName mark={currentTurn} players={players} />            
@@ -72,6 +72,7 @@ const TatetiPage: FunctionComponent<Props> =({className}) => {
                 <b> Scores: </b> <span> {players[Mark.O].name} : </span> <strong> {players[Mark.O].score} </strong>  <b>pts. </b>
             </p>
         )}
+        <InputNameModal open={showModal} onSubmit={(value1, value2) => initGame(value1, value2)} />
     </div>
  )
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "baseUrl": "src"
+    "baseUrl": "."
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      src: "/src",
+    },
+  },
 })


### PR DESCRIPTION
# Problem: 
improve UI by replacing the browser modal  by a custom one.

# solution: 
-A modal was created using "createPortal"
-The input-name-modal component was created that uses the modal to request the names of the players

# test:
Navigate to [tateti page](https://staging.d23b8h4cpmeb82.amplifyapp.com/play/tateti)
press to button Play and verifiy that the modal opens.
add the name's player in the input element then press to play button and check that the game starts.
verify that the game does not start unless both names have been entered.