### PR TITLE
Improvement/add global styled component interface

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "eslint.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit"
-  }
+  },
+  "files.insertFinalNewline": true
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -13,15 +16,23 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-
-    "baseUrl": "."
+    "baseUrl": ".",
+    "typeRoots": [
+      "./node_modules/@types/",
+      "./types/"
+    ],
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/types/styled-component/index.d.ts
+++ b/types/styled-component/index.d.ts
@@ -1,0 +1,3 @@
+interface StyledComponentProps {
+  className?: string;
+}


### PR DESCRIPTION
# Problem
When defining the interfaces of each styled component it is necessary to add the prop className between the properties. This results in boilerplate code

# Solution
- Create a global interface StyledComponentProps that contains the prop className.

## How to use this interface?
- When a component has props
```tsx
const DummyComponent: FunctionComponent<Props> = ({ className }) => {
  ...
}

interface Props extends StyledComponentProps {
  ...
}
```

- When a component does not have props
```tsx
const DummyComponent: FunctionComponent<StyledComponentProps> = ({ className }) => {
  ...
}
```

# Test
- Move to this branch. Check that you can use this interface without having to import it (it is declared as global!).
